### PR TITLE
Collection refactor

### DIFF
--- a/Chocobo/Collection.h
+++ b/Chocobo/Collection.h
@@ -6,6 +6,7 @@
 
 @property (nonatomic, retain) NSMutableArray *models;
 -(id) initWithJson:(NSDictionary*)json;
+-(id) initWithModels:(NSDictionary *)models;
 -(id)model;
 -(NSString *) collectionEndpoint;
 -(void) fetchWithParams:(NSDictionary *)params onSuccess:(void (^)(id responseObject))success onFailure:(void (^)(NSError* error))failure;
@@ -14,4 +15,5 @@
 -(void)addModel:(id)model;
 -(NSDictionary *)parse:(NSDictionary *) responseObject;
 -(void)updateCollectionWithJson:(NSDictionary *)jsonCollection;
+-(void)updateCollectionWithModels:(NSDictionary *)modelsJson;
 @end

--- a/Chocobo/Collection.h
+++ b/Chocobo/Collection.h
@@ -11,6 +11,5 @@
 -(void)clearModels;
 -(NSInteger)modelCount;
 -(void)addModel:(id)model;
--(NSString *)rootKey;
-
+-(NSDictionary *)parse:(NSDictionary *) responseObject;
 @end

--- a/Chocobo/Collection.h
+++ b/Chocobo/Collection.h
@@ -5,7 +5,7 @@
 @interface Collection : AsyncObject
 
 @property (nonatomic, retain) NSMutableArray *models;
-
+-(id) initWithJson:(NSDictionary*)json;
 -(id)model;
 -(NSString *) collectionEndpoint;
 -(void) fetchWithParams:(NSDictionary *)params onSuccess:(void (^)(id responseObject))success onFailure:(void (^)(NSError* error))failure;

--- a/Chocobo/Collection.h
+++ b/Chocobo/Collection.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "AsyncObject.h"
+#import "Model.h"
 
 @interface Collection : AsyncObject
 
@@ -12,4 +13,5 @@
 -(NSInteger)modelCount;
 -(void)addModel:(id)model;
 -(NSDictionary *)parse:(NSDictionary *) responseObject;
+-(void)updateCollectionWithJson:(NSDictionary *)jsonCollection;
 @end

--- a/Chocobo/Collection.m
+++ b/Chocobo/Collection.m
@@ -12,6 +12,14 @@
     }
     return self;
 }
+-(id) initWithModels:(NSDictionary *)models
+{
+    self = [super init];
+    if (self) {
+        [self updateCollectionWithModels:models];
+    }
+    return self;
+}
 
 -(id)model
 {
@@ -52,26 +60,30 @@
     return responseObject;
 }
 
--(void)updateCollectionWithJson:(NSDictionary *)jsonCollection
+-(void)updateCollectionWithModels:(NSDictionary *)modelsJson
 {
-    for (NSDictionary* model in jsonCollection) {
+    for (NSDictionary* model in modelsJson) {
         Class modelClass = NSClassFromString([self model]);
-        id modelObject = [(Model *)[modelClass alloc] initWithJson:modelObject];
+        id modelObject = [(Model *)[modelClass alloc] initWithJson:model];
         // add the object to the model group
         [self.models addObject:modelObject];
     }
+}
+
+-(void)updateCollectionWithJson:(NSDictionary *)jsonCollection
+{
+    NSDictionary *parsedModelsJson = [self parse:jsonCollection];
+    [self updateCollectionWithModels:parsedModelsJson];
 }
 
 -(void) fetchWithParams:(NSDictionary *)params onSuccess:(void (^)(id responseObject))success onFailure:(void (^)(NSError* error))failure
 {
     [self clearModels];
     [self getFromEndpoint:[self collectionEndpoint] withParams:params onSuccess:^(id responseObject) {
-        NSDictionary *attributes = [self parse:responseObject];
         
-        [self updateCollectionWithJson:attributes];
-        
+        [self updateCollectionWithJson:responseObject];
         success(responseObject);
-
+        
     } onFailure:^(NSError *error) {
 
         failure(error);

--- a/Chocobo/Collection.m
+++ b/Chocobo/Collection.m
@@ -38,9 +38,19 @@
     [self.models addObject:model];
 }
 
--(NSDictionary *)parse:(NSDictionary *) responseObject
+-(NSDictionary *)parse:(NSDictionary *)responseObject
 {
     return responseObject;
+}
+
+-(void)updateCollectionWithJson:(NSDictionary *)jsonCollection
+{
+    for (NSDictionary* model in jsonCollection) {
+        Class modelClass = NSClassFromString([self model]);
+        id modelObject = [(Model *)[modelClass alloc] initWithJson:modelObject];
+        // add the object to the model group
+        [self.models addObject:modelObject];
+    }
 }
 
 -(void) fetchWithParams:(NSDictionary *)params onSuccess:(void (^)(id responseObject))success onFailure:(void (^)(NSError* error))failure
@@ -48,18 +58,9 @@
     [self clearModels];
     [self getFromEndpoint:[self collectionEndpoint] withParams:params onSuccess:^(id responseObject) {
         NSDictionary *attributes = [self parse:responseObject];
-
-        for (NSDictionary* key in attributes) {
-
-            Class modelFromString = NSClassFromString([self model]);
-            id modelObject = [[modelFromString alloc] init];
-
-            [modelObject performSelector: NSSelectorFromString(@"updateModelWithJson:") withObject:key];
-
-            // add the object to the model group
-            [self.models addObject:modelObject];
-        }
-
+        
+        [self updateCollectionWithJson:attributes];
+        
         success(responseObject);
 
     } onFailure:^(NSError *error) {

--- a/Chocobo/Collection.m
+++ b/Chocobo/Collection.m
@@ -4,6 +4,15 @@
 
 @synthesize models = _models;
 
+-(id) initWithJson:(NSDictionary *)json
+{
+    self = [super init];
+    if (self) {
+        [self updateCollectionWithJson:json];
+    }
+    return self;
+}
+
 -(id)model
 {
     NSLog(@"[Collectionb] model: method not overriden.");

--- a/Chocobo/Collection.m
+++ b/Chocobo/Collection.m
@@ -38,17 +38,16 @@
     [self.models addObject:model];
 }
 
--(NSString *)rootKey
+-(NSDictionary *)parse:(NSDictionary *) responseObject
 {
-    NSLog(@"[Collection] rootKey method not overriden");
-    return nil;
+    return responseObject;
 }
 
 -(void) fetchWithParams:(NSDictionary *)params onSuccess:(void (^)(id responseObject))success onFailure:(void (^)(NSError* error))failure
 {
     [self clearModels];
     [self getFromEndpoint:[self collectionEndpoint] withParams:params onSuccess:^(id responseObject) {
-        NSDictionary *attributes = [responseObject valueForKey:[self rootKey]];
+        NSDictionary *attributes = [self parse:responseObject];
 
         for (NSDictionary* key in attributes) {
 


### PR DESCRIPTION
I found myself wanting to test some of my own collection subclasses w/o having to necessarily fetch from an access point.

Hence I added the following methods to Collection.m:

```
-(id) initWithJson:(NSDictionary*)json;
-(id) initWithModels:(NSDictionary *)models;
-(void)updateCollectionWithJson:(NSDictionary *)jsonCollection;
-(void)updateCollectionWithModels:(NSDictionary *)modelsJson;
```

Those make it easier to test the collection's logic (e.g.: with loaded JSON stubs.)

Note that this branch has been built upon the changes from pull request #11.

Finally, although the code has been tested, I didn't update the Tests project itself as I wasn't sure wether or not you wanted to change the way tests were organized.
