### PR TITLE
ADDED - Each model now has a `collection` property

### DIFF
--- a/Chocobo/Collection.m
+++ b/Chocobo/Collection.m
@@ -50,8 +50,9 @@
     return [self.models count];
 }
 
--(void)addModel:(id)model
+-(void)addModel:(Model *)model
 {
+    model.collection = self;
     [self.models addObject:model];
 }
 
@@ -66,7 +67,7 @@
         Class modelClass = NSClassFromString([self model]);
         id modelObject = [(Model *)[modelClass alloc] initWithJson:model];
         // add the object to the model group
-        [self.models addObject:modelObject];
+        [self addModel:modelObject];
     }
 }
 

--- a/Chocobo/Model.h
+++ b/Chocobo/Model.h
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 #import "AsyncObject.h"
 
+@class Collection;
+
 @interface Model : AsyncObject
+
+@property (nonatomic, weak) Collection * collection;
 
 -(id) initWithJson:(NSDictionary*)json;
 -(void)updateModelWithJson:(NSDictionary *)json;

--- a/Chocobo/Model.h
+++ b/Chocobo/Model.h
@@ -5,7 +5,7 @@
 
 @interface Model : AsyncObject
 
-@property (nonatomic, weak) Collection * collection;
+@property (nonatomic, strong) Collection * collection;
 
 -(id) initWithJson:(NSDictionary*)json;
 -(void)updateModelWithJson:(NSDictionary *)json;

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		4D827A6B19199AB400591788 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D827A6A19199AB400591788 /* MobileCoreServices.framework */; };
 		4D827A6D19199ABB00591788 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D827A6C19199ABB00591788 /* CFNetwork.framework */; };
 		4D827A6F19199AEA00591788 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D827A6E19199AEA00591788 /* SenTestingKit.framework */; };
+		C0942A18193E7E0100E50CED /* ModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0942A17193E7E0100E50CED /* ModelTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +61,7 @@
 		4D827A6E19199AEA00591788 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		5D1D6DDA50F4466CAC5BAB38 /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = "<group>"; };
 		8F98967DF62149C1BEB05E86 /* Pods-Tests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.xcconfig"; path = "Pods/Pods-Tests.xcconfig"; sourceTree = "<group>"; };
+		C0942A17193E7E0100E50CED /* ModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ModelTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +163,7 @@
 		4D55DA921916B00600EF6D33 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				C0942A16193E7DD900E50CED /* Model */,
 				4D55DAA21916B07C00EF6D33 /* Collection */,
 				4D55DA931916B00600EF6D33 /* Supporting Files */,
 			);
@@ -183,6 +186,14 @@
 				4D55DAA31916B08900EF6D33 /* CollectionTests.m */,
 			);
 			name = Collection;
+			sourceTree = "<group>";
+		};
+		C0942A16193E7DD900E50CED /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C0942A17193E7E0100E50CED /* ModelTests.m */,
+			);
+			name = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -353,6 +364,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D55DAA41916B08900EF6D33 /* CollectionTests.m in Sources */,
+				C0942A18193E7E0100E50CED /* ModelTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/TestsTests/CollectionTests.m
+++ b/Tests/TestsTests/CollectionTests.m
@@ -53,6 +53,12 @@ describe(@"addModel:", ^{
         [collection addModel:model1];
         expect([[collection models] objectAtIndex:0]).to.equal(model1);
     });
+    
+    it(@"has each model's collection property set to itself", ^{
+        [collection addModel:model1];
+        Model * addedModel = [[collection models] objectAtIndex:0];
+        expect(addedModel.collection).to.equal(collection);
+    });
 });
 
 describe(@"clearModels", ^{

--- a/Tests/TestsTests/ModelTests.m
+++ b/Tests/TestsTests/ModelTests.m
@@ -1,0 +1,34 @@
+//
+//  ModelTests.m
+//  Tests
+//
+//  Created by Gabriel Lesperance on 2014-06-03.
+//  Copyright (c) 2014 Gabriel Lesperance. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Specta.h"
+#define EXP_SHORTHAND
+#import "Expecta.h"
+
+#import "Collection.h"
+#import "Model.h"
+
+SpecBegin(Model)
+
+describe(@"general:", ^{
+    __block Model *model;
+    
+    beforeEach(^{
+        Collection * collection = [[Collection alloc] init];
+        model = [[Model alloc] init];
+        [collection addModel:model];
+    });
+    
+    it(@"should have a valid pointer to its collection even when collection is no longer referenced", ^{
+        expect(model.collection).notTo.beNil();
+    });
+});
+
+SpecEnd
+


### PR DESCRIPTION
Each model now has a `collection` property pointing to the collection in which it is contained.

This is necessary if you want to be able to deal with nesting collection within collection ; or in any case where you want the model to be able to access its collection attributes.
